### PR TITLE
[1.10] use docker network (no more link)

### DIFF
--- a/config
+++ b/config
@@ -55,10 +55,6 @@ POSTGRES_VOLUME=$PREFIX/postgres        # docker data volume
 POSTGRES_USER=postgres                  # postgres user
 POSTGRES_PASSWORD=postgres              # postgres password
 
-COOG_DB_USER=$POSTGRES_USER             # coog pg user
-COOG_DB_PASSWORD=$POSTGRES_PASSWORD     # coog pg password
-COOG_DB_NAME=coog                       # coog pg db name
-
 SENTRY_DB_USER=$POSTGRES_USER           # sentry db user
 SENTRY_DB_PASSWORD=$POSTGRES_PASSWORD   # sentry db password
 SENTRY_DB_NAME=sentry                   # sentry db db name
@@ -103,8 +99,14 @@ SENTRY_REDIS_PORT=                      # defaults to redis container
 COOG_IMAGE=coog/coog:master             # docker image
 COOG_VOLUME=$PREFIX/coog                # docker data volume
 
+COOG_EXPOSE_PORT=                              # defaults 
+
 COOG_POSTGRES_HOST=                     # defaults to postgres container
 COOG_POSTGRES_PORT=                     # defaults to postgres container
+
+COOG_DB_USER=$POSTGRES_USER             # coog pg user
+COOG_DB_PASSWORD=$POSTGRES_PASSWORD     # coog pg password
+COOG_DB_NAME=coog                       # coog pg db name
 
 COOG_REDIS_HOST=                        # defaults to redis container
 COOG_REDIS_PORT=                        # defaults to redis container

--- a/config
+++ b/config
@@ -11,7 +11,7 @@ check_docker_version() {
         [ -z "$version" ] && echo can not retrieve docker version && return 1
         local major_version; major_version=$(echo "$version" | cut -d '.' -f 1)
         local minor_version; minor_version=$(echo "$version" | cut -d '.' -f 2)
-        [ "$major_version" -ne "$DOCKER_MAJOR_VERSION" ] && echo docker major version should be = $DOCKER_MAJOR_VERSION && return 1
+        [ "$major_version" -lt "$DOCKER_MAJOR_VERSION" ] && echo docker major version should be = $DOCKER_MAJOR_VERSION && return 1
         [ "$minor_version" -lt "$DOCKER_MINOR_VERSION" ] && echo docker minor version should be at least $DOCKER_MINOR_VERSION && return 1
         return 0
 }
@@ -40,12 +40,16 @@ PREFIX=/usr/local/coog                        # where all custom data goes
 [ ! -z "$COOG_DATA" ] && PREFIX="$COOG_DATA"  # can be set via $COOG_DATA
 mkdir -p "$PREFIX"                            # make sure folder exists
 
+NETWORK_NAME=$USER
+[ -z "$DOCKER_DAEMON_OPTS" ] && DOCKER_DAEMON_OPTS="-d"
+[ -z "$DOCKER_PIPED_OPTS" ] && DOCKER_PIPED_OPTS="--rm"
+[ -z "$DOCKER_INTERACTIVE_OPTS" ] && DOCKER_INTERACTIVE_OPTS="-it --rm"
+
 #-------------------------------------------------------------------------------#
 # POSTGRES CONFIG
 #-------------------------------------------------------------------------------#
 
 POSTGRES_IMAGE=postgres:9.5-alpine      # docker image
-POSTGRES_CONTAINER=$USER-postgres       # docker container
 POSTGRES_VOLUME=$PREFIX/postgres        # docker data volume
 
 POSTGRES_USER=postgres                  # postgres user
@@ -64,7 +68,6 @@ SENTRY_DB_NAME=sentry                   # sentry db db name
 #-------------------------------------------------------------------------------#
 
 REDIS_IMAGE=redis:3.2-alpine            # docker image
-REDIS_CONTAINER=$USER-redis             # docker container
 REDIS_VOLUME=$PREFIX/redis              # docker data volume
 
 COOG_CACHE_DB=0                         # coog cache db name
@@ -83,8 +86,7 @@ UNOCONV_CONTAINER=$USER-unoconv         # docker container
 # SENTRY CONFIG
 #-------------------------------------------------------------------------------#
 
-SENTRY_IMAGE=sentry:8.9                 # docker image
-SENTRY_CONTAINER=$USER-sentry           # docker container
+SENTRY_IMAGE=sentry:8                   # docker image
 SENTRY_VOLUME=$PREFIX/sentry            # docker data volume
 SENTRY_KEY=$PREFIX/sentry.key           # containers shared key
 
@@ -98,8 +100,7 @@ SENTRY_REDIS_PORT=                      # defaults to redis container
 # COOG CONFIG
 #-------------------------------------------------------------------------------#
 
-COOG_IMAGE=coog/coog:1.8                # docker image
-COOG_CONTAINER=$USER-coog               # docker container
+COOG_IMAGE=coog/coog:master             # docker image
 COOG_VOLUME=$PREFIX/coog                # docker data volume
 
 COOG_POSTGRES_HOST=                     # defaults to postgres container
@@ -133,7 +134,6 @@ COOG_ADMIN_EMAIL=example@coopengo.com   # application admin email address
 #-------------------------------------------------------------------------------#
 
 NGINX_IMAGE=nginx:1-alpine              # docker image
-NGINX_CONTAINER=$USER-nginx             # docker container
 NGINX_CONF=$PREFIX/nginx.conf           # nginx conf path
 NGINX_PUB_PORT=80                       # host mapped port
 

--- a/config
+++ b/config
@@ -99,8 +99,6 @@ SENTRY_REDIS_PORT=                      # defaults to redis container
 COOG_IMAGE=coog/coog:coog-1.10          # docker image
 COOG_VOLUME=$PREFIX/coog                # docker data volume
 
-COOG_EXPOSE_PORT=                              # defaults 
-
 COOG_POSTGRES_HOST=                     # defaults to postgres container
 COOG_POSTGRES_PORT=                     # defaults to postgres container
 

--- a/config
+++ b/config
@@ -96,7 +96,7 @@ SENTRY_REDIS_PORT=                      # defaults to redis container
 # COOG CONFIG
 #-------------------------------------------------------------------------------#
 
-COOG_IMAGE=coog/coog:master             # docker image
+COOG_IMAGE=coog/coog:coog-1.10          # docker image
 COOG_VOLUME=$PREFIX/coog                # docker data volume
 
 COOG_EXPOSE_PORT=                              # defaults 

--- a/coog
+++ b/coog
@@ -23,12 +23,8 @@ postgres_args() {
         then
                 args="-e COOG_POSTGRES_HOST=$COOG_POSTGRES_HOST"
                 [ ! -z "$COOG_POSTGRES_PORT" ] && args="$args -e COOG_POSTGRES_PORT=$COOG_POSTGRES_PORT"
-        elif [ ! -z "$POSTGRES_CONTAINER" ]
-        then
-                args="--link $POSTGRES_CONTAINER:postgres"
-                args="$args -e COOG_POSTGRES_HOST=postgres"
         else
-                return 0
+                args="$args -e COOG_POSTGRES_HOST=$NETWORK_NAME-postgres"
         fi
         echo "$args"
 }
@@ -39,12 +35,8 @@ redis_args() {
         then
                 args="-e COOG_REDIS_HOST=$COOG_REDIS_HOST"
                 [ ! -z "$COOG_REDIS_PORT" ] && args="$args -e COOG_REDIS_PORT=$COOG_REDIS_PORT"
-        elif [ ! -z "$REDIS_CONTAINER" ]
-        then
-                args="--link $REDIS_CONTAINER:redis"
-                args="$args -e COOG_REDIS_HOST=redis"
         else
-                return 0
+                args="$args -e COOG_REDIS_HOST=$NETWORK_NAME-redis"
         fi
         echo "$args"
 }
@@ -80,15 +72,9 @@ sentry_args() {
         local args
         if [ -z "$COOG_SENTRY_PROTOCOL" ] || [ -z "$COOG_SENTRY_HOST" ] || [ -z "$COOG_SENTRY_PORT" ]
         then
-                if [ ! -z "$SENTRY_CONTAINER" ]
-                then
-                        args="--link $SENTRY_CONTAINER:sentry"
-                        COOG_SENTRY_PROTOCOL=http
-                        COOG_SENTRY_HOST=sentry
-                        COOG_SENTRY_PORT=9000
-                else
-                        return
-                fi
+                COOG_SENTRY_PROTOCOL=http
+                COOG_SENTRY_HOST="$NETWORK_NAME-sentry"
+                COOG_SENTRY_PORT=9000
         fi
         if [ ! -z "$COOG_SENTRY_PUB" ] && [ ! -z "$COOG_SENTRY_SEC" ] && [ ! -z "$COOG_SENTRY_PROJECT" ]
         then
@@ -136,56 +122,27 @@ _edit_cron() {
         crontab -e
 }
 
-_version() {
-        docker run -t --rm $(_args) "$COOG_IMAGE" version
+_docker() {
+        [ -z "$1" ] && echo missing container && return 1
+        local cont; cont=$1; shift
+        docker "$@" "$NETWORK_NAME-coog-$cont"
 }
 
-_env() {
-        docker run -t --rm $(_args) "$COOG_IMAGE" env
-}
-
-_conf() {
-        docker run -t --rm $(_args) "$COOG_IMAGE" conf
-}
-
-_admin() {
-        docker run -ti --rm $(_args) "$COOG_IMAGE" admin -v -d "$COOG_DB_NAME" "$@"
-}
-
-_cron() {
-        docker run -d $(_args) --name "$COOG_CONTAINER-cron" "$COOG_IMAGE" cron "$@"
-}
-
-_server() {
-        docker run -d $(_args) --name "$COOG_CONTAINER" "$COOG_IMAGE" server "$@"
-}
-
-_celery() {
-        [ -z "$COOG_DB_NAME" ] && echo no db name && return 1
-        docker run -d $(_args) --name "$COOG_CONTAINER-celery-$COOG_DB_NAME" "$COOG_IMAGE" celery "$@"
-}
-
-_rq() {
-        [ -z "$COOG_DB_NAME" ] && echo no db name && return 1
-        [ -z "$1" ] && echo missing args && return 1
-        local id; id=$1; shift
-        docker run -d $(_args) --name "$COOG_CONTAINER-rq-$COOG_DB_NAME-$id" "$COOG_IMAGE" rq "$@"
-}
-
-_batch() {
-        docker run -t --rm $(_args) "$COOG_IMAGE" batch "$@"
-}
-
-_chain() {
-        docker run -t --rm $(_args) "$COOG_IMAGE" chain "$@"
-}
-
-_redis() {
-        docker run -t --rm $(_args) "$COOG_IMAGE" redis "$@"
-}
-
-_action() {
-        docker "$@" "$COOG_CONTAINER"
+_image() {
+        [ -z "$1" ] && echo missing command && return 1
+        local cmd; cmd=$(echo "$1" | cut -d "-" -f "1")
+        local args
+        if [ "$cmd" = "server" ] || [ "$cmd" = "celery" ] || [ "$cmd" = "rq" ]
+        then
+                args="$DOCKER_DAEMON_OPTS --name $NETWORK_NAME-coog-$1"
+        elif [ "$cmd" = "admin" ]
+        then
+                args="$DOCKER_INTERACTIVE_OPTS"
+        else
+                args="$DOCKER_PIPED_OPTS"
+        fi
+        shift
+        docker run --network "$NETWORK_NAME" $args $(_args) "$COOG_IMAGE" "$cmd" "$@"
 }
 
 ########

--- a/coog
+++ b/coog
@@ -142,6 +142,12 @@ _image() {
                 args="$DOCKER_PIPED_OPTS"
         fi
         shift
+        while [[ ! -z "$1" ]]
+        do
+                [ "$1" = "--" ] && shift && break
+                args="$args $1"
+                shift
+        done
         docker run --network "$NETWORK_NAME" $args $(_args) "$COOG_IMAGE" "$cmd" "$@"
 }
 
@@ -156,7 +162,6 @@ usage() {
         echo "  init          -> init volume folder"
         echo "  edit-app      -> edits coog app config file"
         echo "  edit-batch    -> edits coog batch config file"
-        echo "  edit-cron     -> configure cron for a chain execution"
         docker run -t --rm "$COOG_IMAGE"
         echo Docker commands
         echo
@@ -173,21 +178,12 @@ main() {
         local cmd; cmd="$1"; shift
         #
         [ "$cmd" = "init" ] && { _init; return $?; }
+        [ ! -e "$COOG_VOLUME" ] && echo "You need to run: './coog init'" && return 1
         [ "$cmd" = "edit-app" ] && { _edit_app; return $?; }
         [ "$cmd" = "edit-batch" ] && { _edit_batch; return $?; }
         [ "$cmd" = "edit-cron" ] && { _edit_cron; return $?; }
-        [ "$cmd" = "version" ] && { _version; return $?; }
-        [ "$cmd" = "env" ] && { _env; return $?; }
-        [ "$cmd" = "conf" ] && { _conf; return $?; }
-        [ "$cmd" = "admin" ] && { _admin "$@"; return $?; }
-        [ "$cmd" = "cron" ] && { _cron "$@"; return $?; }
-        [ "$cmd" = "server" ] && { _server "$@"; return $?; }
-        [ "$cmd" = "celery" ] && { _celery "$@"; return $?; }
-        [ "$cmd" = "rq" ] && { _rq "$@"; return $?; }
-        [ "$cmd" = "batch" ] && { _batch "$@"; return $?; }
-        [ "$cmd" = "chain" ] && { _chain "$@"; return $?; }
-        [ "$cmd" = "redis" ] && { _redis "$@"; return $?; }
-        _action "$cmd" "$@"
+        [ "$cmd" = "--" ] && { _docker "$@"; return $?; }
+        _image "$cmd" "$@"
 }
 
 main "$@"

--- a/coog_batch_exec
+++ b/coog_batch_exec
@@ -1,0 +1,12 @@
+batch_name=$1;
+num_workers=$2;
+shift 2;
+./coog redis -- celery qremove  $batch_name
+./coog celery -- $num_workers $batch_name
+./coog batch -v $data:/coog/data -- $batch_name $*
+ret_value=$?
+sleep 10
+./coog celery-$batchname stop
+./coog celery-$batchname logs 2>&1
+./coog celery-$batchname rm
+return ret_value

--- a/defaults/nginx.conf
+++ b/defaults/nginx.conf
@@ -39,7 +39,7 @@ http {
         least_conn;
 
         # coog workers (add more from remote hosts)
-        server coog:7999;
+        server NETWORK_NAME-coog-server:7999;
     }
 
     server {

--- a/net
+++ b/net
@@ -1,0 +1,39 @@
+#!/bin/bash
+# vim: set ft=sh:
+# this script creates a docker network for coog
+
+get_dir() {
+        local script_path; script_path=$(readlink -f "$0")
+        local script_dir; script_dir=$(dirname "$script_path")
+        echo "$script_dir"
+}
+
+_create() {
+        docker network create "$NETWORK_NAME"
+}
+
+_rm() {
+        docker network rm "$NETWORK_NAME"
+}
+
+usage() {
+        echo
+        echo Available commands
+        echo
+        echo "  create    -> creates coog network"
+        echo "  rm        -> removes coog network"
+        echo
+}
+
+main() {
+        source "$(get_dir)/config"
+        #
+        [ -z "$1" ] && usage && return 0
+        local cmd; cmd=$1; shift
+        #
+        [ "$cmd" = "create" ] && { _create "$@"; return $?; }
+        [ "$cmd" = "rm" ] && { _rm "$@"; return $?; }
+        echo "bad command" && return 1
+}
+
+main "$@"

--- a/nginx
+++ b/nginx
@@ -12,6 +12,7 @@ get_dir() {
 init() {
         [ -e "$NGINX_CONF" ] && echo backup old config before && return 1
         cp "$(get_dir)/defaults/nginx.conf" "$NGINX_CONF"
+        sed -i "s/NETWORK_NAME/$NETWORK_NAME/g" "$NGINX_CONF"
 }
 
 edit() {
@@ -20,19 +21,20 @@ edit() {
 
 run() {
         docker run \
-                -d \
-                --name "$NGINX_CONTAINER" \
-                --link "$COOG_CONTAINER:coog" \
+                $DOCKER_DAEMON_OPTS \
+                --network "$NETWORK_NAME" \
+                --name "$NETWORK_NAME-nginx" \
                 -v /usr/share/zoneinfo:/usr/share/zoneinfo:ro \
                 -v /etc/timezone:/etc/timezone:ro \
                 -v "$NGINX_CONF:/etc/nginx/nginx.conf:ro" \
-                --volumes-from "$COOG_CONTAINER" \
+                -v "/tmp:/tmp" \
+                --volumes-from "$NETWORK_NAME-coog-server" \
                 -p "$NGINX_PUB_PORT:80" \
-                "$NGINX_IMAGE" "$@"
+                "$NGINX_IMAGE"
 }
 
 action() {
-        docker "$@" "$NGINX_CONTAINER"
+        docker "$@" "$NETWORK_NAME-nginx"
 }
 
 usage() {
@@ -54,7 +56,7 @@ main() {
         #
         [ "$cmd" = "init" ] && { init; return $?; }
         [ "$cmd" = "edit" ] && { edit; return $?; }
-        [ "$cmd" = "run" ] && { run "$@"; return $?; }
+        [ "$cmd" = "run" ] && { run; return $?; }
         action "$cmd" "$@"
 }
 

--- a/nginx
+++ b/nginx
@@ -30,7 +30,7 @@ run() {
                 -v "/tmp:/tmp" \
                 --volumes-from "$NETWORK_NAME-coog-server" \
                 -p "$NGINX_PUB_PORT:80" \
-                "$NGINX_IMAGE"
+                "$NGINX_IMAGE" "$@"
 }
 
 action() {

--- a/postgres
+++ b/postgres
@@ -10,7 +10,15 @@ get_dir() {
 }
 
 server() {
+        local args
+        while [[ ! -z "$1" ]]
+        do
+                [ "$1" = "--" ] && shift && break
+                args="$args $1"
+                shift
+        done
         docker run \
+                $args \
                 $DOCKER_DAEMON_OPTS \
                 --network "$NETWORK_NAME" \
                 --name "$NETWORK_NAME-postgres" \

--- a/postgres
+++ b/postgres
@@ -11,8 +11,9 @@ get_dir() {
 
 server() {
         docker run \
-                -d \
-                --name "$POSTGRES_CONTAINER" \
+                $DOCKER_DAEMON_OPTS \
+                --network "$NETWORK_NAME" \
+                --name "$NETWORK_NAME-postgres" \
                 -e "POSTGRES_USER=$POSTGRES_USER" \
                 -e "POSTGRES_PASSWORD=$POSTGRES_PASSWORD" \
                 -e "PGDATA=/var/lib/postgresql/data/pgdata" \
@@ -23,15 +24,26 @@ server() {
 }
 
 client() {
-        docker run -it --rm \
-                --link "$POSTGRES_CONTAINER:postgres" \
+        docker run \
+                $DOCKER_INTERACTIVE_OPTS \
+                --network "$NETWORK_NAME" \
                 -v "/tmp:/tmp" \
                 "$POSTGRES_IMAGE" \
-                psql -h postgres -U "$POSTGRES_USER" "$@"
+                psql -h "$NETWORK_NAME-postgres" -U "$POSTGRES_USER" "$@"
+}
+
+dump() {
+        docker run \
+                $DOCKER_PIPED_OPTS \
+                --network "$NETWORK_NAME" \
+                -e "PGPASSWORD=$PGPASSWORD" \
+                -v "/tmp:/tmp" \
+                "$POSTGRES_IMAGE" \
+                pg_dump -h "$NETWORK_NAME-postgres" -U "$POSTGRES_USER" "$@"
 }
 
 action() {
-        docker "$@" "$POSTGRES_CONTAINER"
+        docker "$@" "$NETWORK_NAME-postgres"
 }
 
 usage() {

--- a/pull
+++ b/pull
@@ -14,6 +14,7 @@ main() {
         [ ! -z "$POSTGRES_IMAGE" ] && docker pull "$POSTGRES_IMAGE"
         [ ! -z "$REDIS_IMAGE" ] && docker pull "$REDIS_IMAGE"
         [ ! -z "$NGINX_IMAGE" ] && docker pull "$NGINX_IMAGE"
+        [ ! -z "$SENTRY_IMAGE" ] && docker pull "$SENTRY_IMAGE"
 }
 
 main

--- a/redis
+++ b/redis
@@ -11,8 +11,9 @@ get_dir() {
 
 server() {
         docker run \
-                -d \
-                --name "$REDIS_CONTAINER" \
+                $DOCKER_DAEMON_OPTS \
+                --network "$NETWORK_NAME" \
+                --name "$NETWORK_NAME-redis" \
                 -v /usr/share/zoneinfo:/usr/share/zoneinfo:ro \
                 -v /etc/timezone:/etc/timezone:ro \
                 -v "$REDIS_VOLUME:/data" \
@@ -20,15 +21,16 @@ server() {
 }
 
 client() {
-        docker run -it --rm \
-                --link "$REDIS_CONTAINER:redis" \
+        docker run \
+                $DOCKER_INTERACTIVE_OPTS \
+                --network "$NETWORK_NAME" \
                 -v "/tmp:/tmp" \
                 "$REDIS_IMAGE" \
-                redis-cli -h redis "$@"
+                redis-cli -h "$NETWORK_NAME-redis" "$@"
 }
 
 action() {
-        docker "$@" "$REDIS_CONTAINER"
+        docker "$@" "$NETWORK_NAME-redis"
 }
 
 usage() {

--- a/sentry
+++ b/sentry
@@ -53,6 +53,7 @@ cache_args() {
 
 args() {
         local args
+        local secret_key; secret_key=$(get_key)       
         args="-v $SENTRY_VOLUME:/var/lib/sentry/files -e SENTRY_SECRET_KEY=$secret_key"
         echo "$args $(postgres_args) $(redis_args) $(db_args) $(cache_args)"
 }
@@ -138,7 +139,7 @@ usage() {
         echo "  server    -> launches sentry server"
         echo "  client    -> launches sentry client on browser"
         echo "  beat      -> launches sentry cron"
-        echo "  server    -> launches sentry worker"
+        echo "  worker    -> launches sentry worker"
         echo "  <action>  -> calls docker action on server container"
         echo
 }

--- a/sentry
+++ b/sentry
@@ -19,12 +19,8 @@ postgres_args() {
         then
                 args="-e SENTRY_POSTGRES_HOST=$SENTRY_POSTGRES_HOST"
                 [ ! -z "$SENTRY_POSTGRES_PORT" ] && args="$args -e SENTRY_POSTGRES_PORT=$SENTRY_POSTGRES_PORT"
-        elif [ ! -z "$POSTGRES_CONTAINER" ]
-        then
-                args="--link $POSTGRES_CONTAINER:postgres"
-                args="$args -e SENTRY_POSTGRES_HOST=postgres"
         else
-                return 0
+                args="$args -e SENTRY_POSTGRES_HOST=$NETWORK_NAME-postgres"
         fi
         echo "$args"
 }
@@ -35,12 +31,8 @@ redis_args() {
         then
                 args="-e SENTRY_REDIS_HOST=$SENTRY_REDIS_HOST"
                 [ ! -z "$SENTRY_REDIS_PORT" ] && args="$args -e SENTRY_REDIS_PORT=$SENTRY_REDIS_PORT"
-        elif [ ! -z "$REDIS_CONTAINER" ]
-        then
-                args="--link $REDIS_CONTAINER:redis"
-                args="$args -e SENTRY_REDIS_HOST=redis"
         else
-                return 0
+                args="$args -e SENTRY_REDIS_HOST=$NETWORK_NAME-redis"
         fi
         echo "$args"
 }
@@ -95,27 +87,39 @@ edit_conf() {
 }
 
 upgrade() {
-        check_key || return 1
-        docker run -it --rm $(args) "$SENTRY_IMAGE" upgrade "$@"
+        docker run \
+                $DOCKER_INTERACTIVE_OPTS \
+                --network "$NETWORK_NAME" \
+                $(args) "$SENTRY_IMAGE" upgrade "$@"
 }
 
 server() {
-        check_key || return 1
-        docker run -d --name "$SENTRY_CONTAINER" $(args) "$SENTRY_IMAGE" "$@"
+        docker run \
+                $DOCKER_DAEMON_OPTS \
+                --network "$NETWORK_NAME" \
+                --name "$NETWORK_NAME-sentry" \
+                -p "9000:9000" \
+                $(args) "$SENTRY_IMAGE" "$@"
 }
 
 cron() {
-        check_key || return 1
-        docker run -d --name "$SENTRY_CONTAINER-cron" $(args) "$SENTRY_IMAGE" run cron "$@"
+        docker run \
+                $DOCKER_DAEMON_OPTS \
+                --network "$NETWORK_NAME" \
+                --name "$NETWORK_NAME-sentry-cron" \
+                $(args) "$SENTRY_IMAGE" run cron "$@"
 }
 
 worker() {
-        check_key || return 1
-        docker run -d --name "$SENTRY_CONTAINER-worker" $(args) "$SENTRY_IMAGE" run worker "$@"
+        docker run \
+                $DOCKER_DAEMON_OPTS \
+                --network "$NETWORK_NAME" \
+                --name "$NETWORK_NAME-sentry-worker" \
+                $(args) "$SENTRY_IMAGE" run worker "$@"
 }
 
 action() {
-        docker "$@" "$SENTRY_CONTAINER"
+        docker "$@" "$NETWORK_NAME-sentry"
 }
 
 client() {
@@ -151,7 +155,6 @@ main() {
         [ "$cmd" = "edit-conf" ] && { edit_conf; return $?; }
         [ "$cmd" = "upgrade" ] && { upgrade "$@"; return $?; }
         [ "$cmd" = "server" ] && { server "$@"; return $?; }
-        [ "$cmd" = "client" ] && { client; return $?; }
         [ "$cmd" = "cron" ] && { cron "$@"; return $?; }
         [ "$cmd" = "worker" ] && { worker "$@"; return $?; }
         action "$cmd" "$@"

--- a/upgrade
+++ b/upgrade
@@ -12,21 +12,175 @@ get_dir() {
         echo "$script_dir"
 }
 
-clear_cache() {
+docker_image() {
+        [ -z "$1" ] && return 1
+        docker images --format '{{.Repository}}:{{.Tag}}' --filter "reference=$1"
+}
+
+docker_last_image() {
+        docker images --format '{{.Repository}}:{{.Tag}}' | head -1
+}
+
+docker_container() {
+        [ -z "$1" ] && return 1
+        docker ps --format '{{.Names}}' --filter "name=$NETWORK_NAME-$1"
+}
+
+cache_clear() {
         [ ! -z "$COOG_CACHE_DB" ] && "$(get_dir)/redis" client -n "$COOG_CACHE_DB" FLUSHDB
 }
+
+database_backup() {
+        local file_name
+        file_name="coog-$USER-$COOG_DB_NAME-$(date +'%y%m%d-%H%M%S').dmp"
+        if [ -z "$COOG_POSTGRES_HOST" ]
+        then
+                docker run \
+                        $DOCKER_PIPED_OPTS \
+                        --network "$NETWORK_NAME" \
+                        -e PGHOST="$NETWORK_NAME" \
+                        -e PGUSER="$POSTGRES_USER" \
+                        -e PGPASSWORD="$POSTGRES_PASSWORD" \
+                        -v "/tmp:/tmp" \
+                        "$POSTGRES_IMAGE" \
+                        pg_dump -F c "$COOG_DB_NAME" > "/tmp/$file_name"
+        else
+                docker run \
+                        $DOCKER_PIPED_OPTS \
+                        -e PGHOST="$COOG_POSTGRES_HOST" \
+                        -e PGUSER="$POSTGRES_USER" \
+                        -e PGPASSWORD="$POSTGRES_PASSWORD" \
+                        -v "/tmp:/tmp" \
+                        "$POSTGRES_IMAGE" \
+                        pg_dump -F c "$COOG_DB_NAME" > "/tmp/$file_name"
+        fi
+}
+
+database_update() {
+        "$dir/coog" admin -u ir "$@"
+}
+
+print_help() {
+        echo "This command upgrades Coog installation"
+        echo
+        echo "Command options:"
+        echo "  -t <image-tag>"
+        echo "  -a <image-archive>"
+        echo "  -s <server-workers-number>"
+        echo "  -c <celery-workers-number>"
+        echo "  -b : backup database"
+        echo "  -u : update database"
+        echo "  -h : print this help"
+        echo
+        echo "Extra parameters will be forwarded to the database update command"
+}
+
+while getopts "t:a:s:c:buh" opt
+do
+        case "$opt" in
+                t) COOG_IMAGE_TAG="$OPTARG"
+                        ;;
+                a) COOG_IMAGE_ARCHIVE="$OPTARG"
+                        ;;
+                s) COOG_SERVER_WORKERS="$OPTARG"
+                        ;;
+                c) COOG_CELERY_WORKERS="$OPTARG"
+                        ;;
+                b) COOG_DB_BACKUP=y
+                        ;;
+                u) COOG_DB_UPDATE=y
+                        ;;
+                h) print_help && exit 0
+                        ;;
+        esac
+done
+shift $((OPTIND-1))
 
 main() {
         local dir
         dir=$(get_dir)
         source "$dir/config"
-        docker load -i "$1" || exit $?
-        echo COOG_IMAGE="$(docker images --format '{{.Repository}}:{{.Tag}}' | head -1)" >> "$PREFIX/config"
-        "$dir/coog" rm -f
-        clear_cache
-        "$dir/coog" admin -u ir
-        clear_cache
-        "$dir/coog" server "$2"
+        [ ! -z "$DB_NAME" ] && COOG_DB_NAME="$DB_NAME"
+        if [ "$COOG_IMAGE_ARCHIVE" != "-" ]
+        then
+                echo
+                echo "loading image from $COOG_IMAGE_ARCHIVE"
+                docker load -i "$COOG_IMAGE_ARCHIVE" || return $?
+                COOG_IMAGE_TAG="$(docker_last_image)"
+        fi
+        if [ "$COOG_IMAGE_TAG" != "-" ]
+        then
+                local img
+                img=$(docker_image "$COOG_IMAGE_TAG")
+                echo
+                if [ ! -z "$img" ]
+                then
+                        echo "adding $COOG_IMAGE_TAG image to config"
+                        echo "COOG_IMAGE=$COOG_IMAGE_TAG" >> "$PREFIX/config"
+                else
+                        echo "$COOG_IMAGE_TAG image not found"
+                        return 1
+                fi
+        fi
+        local nginx_container
+        nginx_container=$(docker_container nginx)
+        echo
+        if [ ! -z "$nginx_container" ]
+        then
+                echo "removing nginx container"
+                "$dir/nginx" rm -f
+        else
+                echo "no nginx container running"
+        fi
+        local server_container
+        server_container=$(docker_container coog-server)
+        echo
+        if [ ! -z "$server_container" ]
+        then
+                echo "removing server container"
+                "$dir/coog" -- server rm -f
+        else
+                echo "no server container running"
+        fi
+        local celery_container
+        celery_container=$(docker_container coog-celery)
+        echo
+        if [ ! -z "$celery_container" ]
+        then
+                echo "removing celery container"
+                "$dir/coog" -- celery rm -f
+        else
+                echo "no celery container running"
+        fi
+        echo
+        echo "clearing cache" && { cache_clear || return $?; }
+        if [ "$COOG_DB_BACKUP" = y ]
+        then
+                echo "backup database" && { database_backup || return $?; }
+        fi
+        if [ "$COOG_DB_UPDATE" = y ]
+        then
+                echo "updating database" && { database_update "$@" || return $?; }
+                echo "clearing cache" && { cache_clear || return $?; }
+        fi
+        if [ ! -z "$celery_container" ]
+        then
+                echo
+                echo "starting celery container"
+                "$dir/coog" celery "$COOG_CELERY_WORKERS"
+        fi
+        if [ ! -z "$server_container" ]
+        then
+                echo
+                echo "starting server container"
+                "$dir/coog" server "$COOG_SERVER_WORKERS"
+        fi
+        if [ ! -z "$nginx_container" ]
+        then
+                echo
+                echo "starting nginx container"
+                "$dir/nginx" run
+        fi
 }
 
 main "$@"

--- a/upgrade
+++ b/upgrade
@@ -142,16 +142,6 @@ main() {
         else
                 echo "no server container running"
         fi
-        local celery_container
-        celery_container=$(docker_container coog-celery)
-        echo
-        if [ ! -z "$celery_container" ]
-        then
-                echo "removing celery container"
-                "$dir/coog" -- celery rm -f
-        else
-                echo "no celery container running"
-        fi
         echo
         echo "clearing cache" && { cache_clear || return $?; }
         if [ "$COOG_DB_BACKUP" = y ]
@@ -162,12 +152,6 @@ main() {
         then
                 echo "updating database" && { database_update "$@" || return $?; }
                 echo "clearing cache" && { cache_clear || return $?; }
-        fi
-        if [ ! -z "$celery_container" ]
-        then
-                echo
-                echo "starting celery container"
-                "$dir/coog" celery "$COOG_CELERY_WORKERS"
         fi
         if [ ! -z "$server_container" ]
         then

--- a/upgrade
+++ b/upgrade
@@ -157,7 +157,7 @@ main() {
         then
                 echo
                 echo "starting server container"
-                "$dir/coog" server "$COOG_SERVER_WORKERS"
+                "$dir/coog" server -- "$COOG_SERVER_WORKERS"
         fi
         if [ ! -z "$nginx_container" ]
         then


### PR DESCRIPTION
- Report network management in 1.10 version
- Make it possible to provide extra parameters to docker in coog scripts (parameters before '--' are provided to docker, those after '--' are provided to coog command) -> allows for instance to expose coog on a given port or to bind extra folders to keep version compatibility)
- Fix Sentry script (secret key not provided)
- Add Sentry in pull script
- Allows to name server containers with different names (in order to launch several coog server containers)