### PR TITLE
Remove NGINX_TIMEOUT

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,4 @@
+OTH#0000: Remove NGINX_TIMEOUT
 BUG#9961: Change attachment tar process
 FEA#9455: Add how to on volume management
 BUG#9154: Set return value of backup > save command

--- a/config
+++ b/config
@@ -129,7 +129,6 @@ WEB_IMAGE=coopengo/web:master           # docker image
 NGINX_IMAGE=nginx:1-alpine              # docker image
 NGINX_VOLUME=$COOG_DATA_DIR/nginx       # nginx conf folder
 NGINX_PUB_PORT=80                       # host mapped port
-NGINX_TIMEOUT=$COOG_TIMEOUT             # Same Timeout as Coog
 NGINX_SSL_PUB_PORT=443                  # SSL host mapped port
 NGINX_SSL_METHOD=                       # SSL method (LETSENCRYPT or CUSTOM_KEYS)
 NGINX_SSL_SERVER_NAME=                  # SSL server name
@@ -201,14 +200,19 @@ BI_DB_NAME="$ETL_TARGET_DB_NAME"
 BI_PORT=4242
 
 #-------------------------------------------------------------------------------#
-# INIT
-#-------------------------------------------------------------------------------#
-
-source "$COOG_CODE_DIR/config.fn"
-config_check || exit 1
-
-#-------------------------------------------------------------------------------#
 # CUSTOMS
 #-------------------------------------------------------------------------------#
 
 source "$COOG_DATA_DIR/config"
+
+#-------------------------------------------------------------------------------#
+# INIT
+#-------------------------------------------------------------------------------#
+
+source "$COOG_CODE_DIR/config.fn"
+
+#-------------------------------------------------------------------------------#
+# VALIDATE CONFIG
+#-------------------------------------------------------------------------------#
+
+config_check || exit 1

--- a/config.fn
+++ b/config.fn
@@ -130,8 +130,7 @@ config_data_reset_nginx_sedf() {
     sed -i "s/NETWORK_NAME/$NETWORK_NAME/g" "$1" \
         && sed -i "s/NGINX_SERVER_CONF/$NGINX_SERVER_CONF/g" "$1" \
         && sed -i "s/NGINX_SSL_SERVER_NAME/$NGINX_SSL_SERVER_NAME/g" "$1" \
-        && sed -i "s/COOG_DB_NAME/$COOG_DB_NAME/g" "$1" \
-        && sed -i "s/NGINX_TIMEOUT/$NGINX_TIMEOUT/g" "$1"
+        && sed -i "s/COOG_DB_NAME/$COOG_DB_NAME/g" "$1"
 }
 
 config_data_reset_nginx_sed() {

--- a/coog
+++ b/coog
@@ -93,6 +93,7 @@ _args() {
     local args
     args="-v $COOG_VOLUME:/workspace/io"
     [ ! -z "$COOG_LOG_LEVEL" ] && args="$args -e LOG_LEVEL=$COOG_LOG_LEVEL"
+    [ ! -z "$COOG_TIMEOUT" ] && args="$args -e COOG_TIMEOUT=$COOG_TIMEOUT"
     [ ! -z "$COOG_ADMIN_EMAIL" ] && args="$args -e COOG_ADMIN_EMAIL=$COOG_ADMIN_EMAIL"
     [ ! -z "$COOG_SERVER_WORKERS" ] && args="$args -e COOG_SERVER_WORKERS=$COOG_SERVER_WORKERS"
     [ ! -z "$COOG_CELERY_WORKERS" ] && args="$args -e COOG_CELERY_WORKERS=$COOG_CELERY_WORKERS"

--- a/defaults/nginx/nginx.conf
+++ b/defaults/nginx/nginx.conf
@@ -30,12 +30,12 @@ http {
 
     # timeout in seconds (nginx <-> client)
     # depends on heaviest transactions
-    send_timeout NGINX_TIMEOUT;
+    send_timeout 600;
 
     # timeout in seconds (nginx <-> backend)
     # depends on heaviest transactions
-    proxy_send_timeout NGINX_TIMEOUT;
-    proxy_read_timeout NGINX_TIMEOUT;
+    proxy_send_timeout 600;
+    proxy_read_timeout 600;
 
     include /etc/nginx/coog/http-coog.conf;
     include /etc/nginx/coog/http-web.conf;


### PR DESCRIPTION
It was unusable since it was only effectively applied when
reseting the configuration

Fix #0000