### PR TITLE
coog-admin: Fix clean of year/month/week(ly) attachments

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,4 @@
+BUG#10718: Fix clean of year/month/week(ly) attachements
 FEA#10334: Add config for api cors
 FEA#10145: Add "./coog demo" command to generate a new database
 OTH#0000: Remove NGINX_TIMEOUT

--- a/backup
+++ b/backup
@@ -124,17 +124,17 @@ clean() {
 
     if [[ $stock_weekly_attach -gt 0 ]]; then
         echo "cleaning weekly attachments"
-        cd $BACKUP_DIRECTORY && rm $(ls -t $BACKUP_DIRECTORY/*week*attachments* | tail -$stock_weekly_db)
+        cd $BACKUP_DIRECTORY && rm $(ls -t $BACKUP_DIRECTORY/*week*attachments* | tail -$stock_weekly_attach)
     fi
 
     if [[ $stock_monthly_attach -gt 0 ]]; then
         echo "cleaning monthly attachments"
-        cd $BACKUP_DIRECTORY && rm $(ls -t $BACKUP_DIRECTORY/*month*attachments* | tail -$stock_monthly_db)
+        cd $BACKUP_DIRECTORY && rm $(ls -t $BACKUP_DIRECTORY/*month*attachments* | tail -$stock_monthly_attach)
     fi
 
     if [[ $stock_yearly_attach -gt 0 ]]; then
         echo "cleaning yearly attachments"
-        cd $BACKUP_DIRECTORY && rm $(ls -t $BACKUP_DIRECTORY/*year*attachments* | tail -$stock_yearly_db)
+        cd $BACKUP_DIRECTORY && rm $(ls -t $BACKUP_DIRECTORY/*year*attachments* | tail -$stock_yearly_attach)
     fi
 }
 


### PR DESCRIPTION
Fix #10718