### PR TITLE
ep: set celery max-tasks-per-child to 1 to prevent running out of memory

### DIFF
--- a/images/coog/ep
+++ b/images/coog/ep
@@ -245,6 +245,7 @@ _celery() {
         --app=async.broker_celery \
         --loglevel="$LOG_LEVEL" \
         --concurrency="$n" \
+        --max-tasks-per-child=1 \
         --queues="$q"
 }
 


### PR DESCRIPTION
cf BFM-266